### PR TITLE
최신 이미지 tar 파일로 변경

### DIFF
--- a/installation_guide_21/kubespray/offline-intro.adoc
+++ b/installation_guide_21/kubespray/offline-intro.adoc
@@ -225,17 +225,19 @@ registries.conf 파일의 인자 값에 대한 설명은 다음과 같다.
 |{INTERNAL_IP:PORT}|이미지 레지스트리를 구성할 서버의 IP 주소와 Registry 이미지의 포트 번호 (예: 10.0.10.50:5000)
 |====================
 
-. *supercloud-images.tar 및 registry.tar 다운로드*
+. *supercloud-images.tar 및 registry.tar 다운로드* (QA: supercloud-images -> hypercloud23-images)
 +
-아래의 FTP 서버에서 supercloud-images.tar와 registry.tar를 다운로드한다.
+아래의 FTP 서버에서 supercloud-images.tar와 registry.tar를 다운로드한다. (QA: supercloud-images -> hypercloud23-images)
 +
 [NOTE]
 ==== 
-*supercloud-images.tar* 파일은 HyperCloud 설치에 필요한 이미지 파일이고, *registry.tar* 파일은 이미지 레지스트리를 구성하기 위한 Registry 이미지 파일이다.
+*supercloud-images.tar* 파일은 HyperCloud 설치에 필요한 이미지 파일이고, *registry.tar* 파일은 이미지 레지스트리를 구성하기 위한 Registry 이미지 파일이다. +
+(QA: *hypercloud23-images.tar* 파일은 HyperCloud 설치에 필요한 이미지 파일이고, *registry.tar* 파일은 이미지 레지스트리를 구성하기 위한 Registry 이미지 파일이다.)
 ====
 +
 ----
-192.168.1.150:/home/ck-ftp/k8s/install/offline/supercloud-images
+192.168.1.150:/home/ck-ftp/k8s/install/offline/supercloud-images 
+(QA: 192.168.1.150:/home/ck-ftp/k8s/install/offline/supercloud-images 폴더 내 hypercloud23-images.tar, registry.tar 이미지 다운로드)
 ----
 
 . *이미지 파일 로드*
@@ -248,11 +250,12 @@ $ podman load -i registry.tar
 
 . *컨테이너 실행*
 +
-다운로드한 supercloud-images.tar 파일을 압축 해제한 후 해당 이미지를 이용해서 컨테이너를 실행한다.
+다운로드한 supercloud-images.tar 파일을 압축 해제한 후 해당 이미지를 이용해서 컨테이너를 실행한다. (QA: supercloud-images -> hypercloud23-images)
 +
-.supercloud-images.tar 파일 압축 해제
+.supercloud-images.tar 파일 압축 해제 (QA: supercloud-images -> hypercloud23-images)
 ----
-$ tar -xvf supercloud-images.tar
+$ tar -xvf supercloud-images.tar +
+(QA: tar -xvf hypercloud23-images.tar)
 ----
 +
 .컨테이너 실행
@@ -266,7 +269,8 @@ $ podman run -it -d -p{IMAGE_REGISTRY_IP:PORT}:5000 --privileged -v {IMAGE_FILE_
 |====================
 |인자 값|설명
 |{IMAGE_REGISTRY_IP:PORT}|이미지 레지스트리를 구성한 서버의 IP 주소와 Registry 이미지의 포트 번호 (예: 10.0.10.50:5000)
-|{IMAGE_FILE_PATH}|supercloud-images.tar 파일의 압축을 해제한 경로 입력 (예: /root/supercloud-registry)
+|{IMAGE_FILE_PATH}|supercloud-images.tar 파일의 압축을 해제한 경로 입력 (예: /root/supercloud-registry) +
+(QA: hypercloud23-images.tar 파일의 압축을 해제한 경로 입력 (예: /root/hypercloud23-registry)
 |====================
 
 === SSH 키 배포


### PR DESCRIPTION
사용하는 이미지 tar 파일이 supercloud-images.tar -> hypercloud23-images.tar 파일로 변경
위치 : k8s/install/offline/supercloud-images 안에 릴리즈용 이미지 파일인 hypercloud23-images.tar 추가할 예정